### PR TITLE
Fix RSS icon appearing on the join site

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -10,20 +10,19 @@
  */
 ?>
 
-	<?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
-		<div id="secondary" class="widget-area" role="complementary">
-                    <div id="logo">
-                        <a href="<?php echo esc_attr(get_bloginfo( 'url' )); ?>" title="<?php echo esc_attr(get_bloginfo( 'name' )); ?> home (recent posts)"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/osm-logo.png" width="135" height="135" alt="OSM logo" id="logo"/></a>
-                        <h1><?php echo esc_attr(get_bloginfo( 'name' )); ?></h1>
-                    </div>
-                    <aside id="rss-widget">
-                        <h3 class="widget-title">Subscribe</h3>
-                        <div class="rss-content">
-                            <a href="<?php bloginfo('rss2_url'); ?>"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/rss.png" width="40" height="40" alt="RSS" class="rss-icon"/></a>
-                            via RSS	
-                        </div>
-                    </aside>
-
-			<?php dynamic_sidebar( 'sidebar-1' ); ?>
-		</div><!-- #secondary -->
-	<?php endif; ?>
+    <?php if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
+        <div id="secondary" class="widget-area" role="complementary">
+            <div id="logo">
+                <a href="<?php echo esc_attr(get_bloginfo( 'url' )); ?>" title="<?php echo esc_attr(get_bloginfo( 'name' )); ?> home (recent posts)"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/osm-logo.png" width="135" height="135" alt="OSM logo" id="logo"/></a>
+                <h1><?php echo esc_attr(get_bloginfo( 'name' )); ?></h1>
+            </div>
+            <aside id="rss-widget">
+                <h3 class="widget-title">Subscribe</h3>
+                <div class="rss-content">
+                    <a href="<?php bloginfo('rss2_url'); ?>"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/rss.png" width="40" height="40" alt="RSS" class="rss-icon"/></a>
+                    via RSS
+                </div>
+            </aside>
+            <?php dynamic_sidebar( 'sidebar-1' ); ?>
+        </div><!-- #secondary -->
+    <?php endif; ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -16,13 +16,17 @@
                 <a href="<?php echo esc_attr(get_bloginfo( 'url' )); ?>" title="<?php echo esc_attr(get_bloginfo( 'name' )); ?> home (recent posts)"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/osm-logo.png" width="135" height="135" alt="OSM logo" id="logo"/></a>
                 <h1><?php echo esc_attr(get_bloginfo( 'name' )); ?></h1>
             </div>
-            <aside id="rss-widget">
-                <h3 class="widget-title">Subscribe</h3>
-                <div class="rss-content">
-                    <a href="<?php bloginfo('rss2_url'); ?>"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/rss.png" width="40" height="40" alt="RSS" class="rss-icon"/></a>
-                    via RSS
-                </div>
-            </aside>
+
+            <?php if (wp_count_posts()->publish > 1) { ?>
+                <aside id="rss-widget">
+                    <h3 class="widget-title">Subscribe</h3>
+                    <div class="rss-content">
+                        <a href="<?php bloginfo('rss2_url'); ?>"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/rss.png" width="40" height="40" alt="RSS" class="rss-icon"/></a>
+                        via RSS
+                    </div>
+                </aside>
+            <?php } ?>
             <?php dynamic_sidebar( 'sidebar-1' ); ?>
         </div><!-- #secondary -->
     <?php endif; ?>
+:


### PR DESCRIPTION
For a wordpress install with zero or one post (not really being used for blogging), do not show the RSS icon.

Fixes: #6 (I think) It should prevent it showing up on https://join.osmfoundation.org assuming that site has no blog posts.