### PR TITLE
Remove erroneously added colon

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -29,4 +29,3 @@
             <?php dynamic_sidebar( 'sidebar-1' ); ?>
         </div><!-- #secondary -->
     <?php endif; ?>
-:


### PR DESCRIPTION
This colon was introduced in 8cd22c41 and is showing up above the vertical gray line between sidebar and main content, on both https://join.osmfoundation.org and https://blog.osmfoundation.org: 
![colon-error](https://user-images.githubusercontent.com/311436/66235834-4fb0bb80-e6f1-11e9-88a7-b8cea092a60f.png)
I assume that this was not intentional, therefore this pull request removes the colon character from the theme.