### PR TITLE
Reduce size of the RSS icon

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -19,10 +19,8 @@
 
             <?php if (wp_count_posts()->publish > 1) { ?>
                 <aside id="rss-widget">
-                    <h3 class="widget-title">Subscribe</h3>
                     <div class="rss-content">
-                        <a href="<?php bloginfo('rss2_url'); ?>"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/rss.png" width="40" height="40" alt="RSS" class="rss-icon"/></a>
-                        via RSS
+                        <a href="<?php bloginfo('rss2_url'); ?>"><img src="<?php bloginfo('stylesheet_directory'); ?>/images/rss.png" width="20" height="20" alt="RSS" class="rss-icon"> Subsribe via RSS</a>
                     </div>
                 </aside>
             <?php } ?>

--- a/style.css
+++ b/style.css
@@ -595,14 +595,15 @@ aside#rss-widget {
 
 .rss-icon {
    float: left;
-   padding-right: 10px;
+   padding-right: 6px;
 }
 
 .rss-content {
    overflow: auto;
-   line-height: 38px;
-   color: #757575;
    font-size: 0.928571rem;
+}
+.rss-content a {
+  color: #757575;
 }
 
 /* Navigation Menu */


### PR DESCRIPTION
Reduce the size of the RSS icon and reduce its pominence by removing the
heading.

Before & After:
![rss icon before after](https://user-images.githubusercontent.com/227525/118904917-b577a880-b912-11eb-8728-3350285e37c6.png)
